### PR TITLE
로컬 테스트 환경 구축 위한 docker 코드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+### Mysql
+docker/mysql/data/
+
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm
 /upload/
 /.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Belf 서비스에서 사용되는 파일 등의 정적 데이터를 관리하는
 
 ### 공통
 
-1. Belf 프로젝트인 todo-service 내부의 docker/mysql/README.md 파일을 참고해 개발용 DB를 구성합니다.
+1. oauth 서비스의 `mysql` 서비스를 구동하거나, `docker-compose.yml` 파일에서 `mysql` 서비스만 구동해 DB를 띄워두세요.
 
 ### VSCode
 
@@ -127,7 +127,7 @@ Belf 서비스에서 사용되는 파일 등의 정적 데이터를 관리하는
 | STORAGE_SERVICE_UPLOAD_ABS_PATH      | 🚫  |   ✅    |                 | /mnt/mount/azure/files/storage  | `Azure Files`와 `mount`될 `directory` 전체 경로를 지정합니다.             |
 | STORAGE_SERVICE_UPLOAD_RELATIVE_PATH | ✅  |   🚫    |     /upload     | /upload                         | 파일을 업로드 할 `project directory` 하위의 상대 경로를 지정합니다.       |
 | STORAGE_SERVICE_DB_HOST              | ✅  |   ✅    |    127.0.0.1    | 127.0.0.1, host.docker.internal | 접속할 `Master DB`의 `IP` 혹은 `URL` 설정을 위한 값입니다.                |
-| STORAGE_SERVICE_DB_PORT              | ✅  |   ✅    |      3306       | 3306                            | 접속할 `Master DB`의 `Port` 설정을 위한 값입니다.                         |
+| STORAGE_SERVICE_DB_PORT              | ✅  |   ✅    |      3306       | 3306, 3307                      | 접속할 `Master DB`의 `Port` 설정을 위한 값입니다.                         |
 | STORAGE_SERVICE_DB_NAME              | ✅  |   ✅    |      belf       | belf                            | 접속할 `DB`의 `DB Name` 설정을 위한 값입니다.                             |
 | STORAGE_SERVICE_DB_USER              | ✅  |   ✅    |      root       | root                            | 접속할 `DB`의 `User Name` 설정을 위한 값입니다.                           |
 | STORAGE_SERVICE_DB_PASSWORD          | ✅  |   ✅    |     example     | example                         | 접속할 `DB`의 `User Password` 설정을 위한 값입니다.                       |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./docker/mysql
       dockerfile: Dockerfile
-    image: belf-mysql
+    image: belf-storage-mysql
     container_name: mysql-storage-dev
     volumes:
       - ./docker/mysql/data:/var/lib/mysql
@@ -16,6 +16,8 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
   storage-service:
+    depends_on:
+      - mysql
     build:
       context: "./"
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./docker/mysql
       dockerfile: Dockerfile
-    image: belf-storage-mysql
+    image: jp3pe/belf-kr/storage-mysql-service
     container_name: mysql-storage-dev
     volumes:
       - ./docker/mysql/data:/var/lib/mysql
@@ -21,7 +21,7 @@ services:
     build:
       context: "./"
       dockerfile: Dockerfile
-    image: "ghcr.io/belf-kr/storage-service"
+    image: "jp3pe/belf-kr/storage-service"
     container_name: "belf-storage-service"
     environment:
       - STORAGE_SERVICE_APP_NAME=STORAGE_SERVICE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,20 @@
 version: "3.8"
 services:
+  # oauth 서비스에서 가져옴
+  mysql:
+    build:
+      context: ./docker/mysql
+      dockerfile: Dockerfile
+    image: belf-mysql
+    container_name: mysql-storage-dev
+    volumes:
+      - ./docker/mysql/data:/var/lib/mysql
+    ports:
+      - "3307:3306"
+    command:
+      # 한글과 이모지 입력을 위하여 기본 문자셋 인코딩 변경
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
   storage-service:
     build:
       context: "./"
@@ -14,7 +29,7 @@ services:
       - STORAGE_SERVICE_ACCESS_LOG=true
       - STORAGE_SERVICE_UPLOAD_ABS_PATH=/home/sanic/project/upload
       - STORAGE_SERVICE_DB_HOST=host.docker.internal
-      - STORAGE_SERVICE_DB_PORT=3306
+      - STORAGE_SERVICE_DB_PORT=3307
       - STORAGE_SERVICE_DB_NAME=belf
       - STORAGE_SERVICE_DB_USER=root
       - STORAGE_SERVICE_DB_PASSWORD=example

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,0 +1,5 @@
+FROM mysql:5.7.16
+
+ENV MYSQL_ROOT_PASSWORD=example
+
+COPY ./init.sql /docker-entrypoint-initdb.d

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -1,0 +1,1 @@
+create database belf;


### PR DESCRIPTION
# 변경 내역

1. docker-compose.yml 파일 내부에 MySQL 구축위한 코드 추가

# 변경 사유

1. 명령어 1줄을 사용해 storage service 동작 여부 확인

# 테스트 방법

1. `docker-compose up -d` 명령어를 사용했을떄 storage service, Mysql service가 정상적으로 올라오는지 확인합니다.