### PR TITLE
Production 환경인 경우 플래그 값으로 환경변수 가져오는 기능으로 수정

### DIFF
--- a/Config/DatabaseConfig.py
+++ b/Config/DatabaseConfig.py
@@ -10,28 +10,20 @@ class DatabaseConfig(BaseConfig):
     def __init__(self):
         super().__init__()
 
-        self.DB_HOST = get_environment_variable("STORAGE_SERVICE_DB_HOST")
-        self.DB_PORT = get_environment_variable("STORAGE_SERVICE_DB_PORT")
-        self.DB_NAME = get_environment_variable("STORAGE_SERVICE_DB_NAME")
-        self.DB_USER = get_environment_variable("STORAGE_SERVICE_DB_USER")
-        self.DB_PASSWORD = get_environment_variable("STORAGE_SERVICE_DB_PASSWORD")
+        if get_environment_variable("STORAGE_SERVICE_IS_PROD"):
+            self.DB_HOST = get_environment_variable("STORAGE_SERVICE_DB_HOST")
+            self.DB_PORT = get_environment_variable("STORAGE_SERVICE_DB_PORT")
+            self.DB_NAME = get_environment_variable("STORAGE_SERVICE_DB_NAME")
+            self.DB_USER = get_environment_variable("STORAGE_SERVICE_DB_USER")
+            self.DB_PASSWORD = get_environment_variable("STORAGE_SERVICE_DB_PASSWORD")
+        else:
+            with open(BaseConfig.get_instance().DB_CONFIG_PATH, "r") as f:
+                content = json.load(f)
 
-        with open(BaseConfig.get_instance().DB_CONFIG_PATH, "r") as f:
-            content = json.load(f)
-
-            if not self.DB_HOST:
                 self.DB_HOST = content["STORAGE_SERVICE_DB_HOST"]
-
-            if not self.DB_PORT:
                 self.DB_PORT = content["STORAGE_SERVICE_DB_PORT"]
-
-            if not self.DB_NAME:
                 self.DB_NAME = content["STORAGE_SERVICE_DB_NAME"]
-
-            if not self.DB_USER:
                 self.DB_USER = content["STORAGE_SERVICE_DB_USER"]
-
-            if not self.DB_PASSWORD:
                 self.DB_PASSWORD = content["STORAGE_SERVICE_DB_PASSWORD"]
 
     @classmethod


### PR DESCRIPTION
# 변경 내역

1. QA, Prod 환경인 경우 공백 문자도 DB 관련 연결 설정값에 입력되게 변경

# 변경 사유

1. DB 비밀번호 값이 비어있는 경우 로컬의 개발용 .json 파일에서 값을 불러옴

# 테스트 방법

1. DB 서비스 기능이 동작하는지 확인합니다.