### PR TITLE
201 응답에 Access-Control-Allow-Origin : * 헤더 추가 

### DIFF
--- a/API/Upload.py
+++ b/API/Upload.py
@@ -51,9 +51,5 @@ async def file_upload(request: Request):
 
     location = f"{API.api.version_prefix}{API.api.version}{API.download.url_prefix}"
     location += f"?{Query.FILE_ID.value}={str(file_model.pk)}"
-    headers = {
-        "Location": location,
-        "Access-Control-Allow-Origin": "*"
-    }
 
-    return empty(status=HTTPStatus.CREATED, headers=headers)
+    return empty(status=HTTPStatus.CREATED, headers={"Location": location})

--- a/API/Upload.py
+++ b/API/Upload.py
@@ -51,5 +51,9 @@ async def file_upload(request: Request):
 
     location = f"{API.api.version_prefix}{API.api.version}{API.download.url_prefix}"
     location += f"?{Query.FILE_ID.value}={str(file_model.pk)}"
+    headers = {
+        "Location": location,
+        "Access-Control-Allow-Origin": "*"
+    }
 
-    return empty(status=HTTPStatus.CREATED, headers={"Location": location})
+    return empty(status=HTTPStatus.CREATED, headers=headers)

--- a/API/Upload.py
+++ b/API/Upload.py
@@ -51,5 +51,9 @@ async def file_upload(request: Request):
 
     location = f"{API.api.version_prefix}{API.api.version}{API.download.url_prefix}"
     location += f"?{Query.FILE_ID.value}={str(file_model.pk)}"
+    headers = {
+        "Access-Control-Expose-Headers": "*",
+        "Location": location
+    }
 
-    return empty(status=HTTPStatus.CREATED, headers={"Location": location})
+    return empty(status=HTTPStatus.CREATED, headers=headers)

--- a/Application.py
+++ b/Application.py
@@ -20,7 +20,8 @@ from sanic.config import (
 from sanic.handlers import ErrorHandler
 from sanic.router import Router
 from sanic.signals import SignalRouter
-from sanic_cors import CORS
+from sanic_plugin_toolkit import SanicPluginRealm
+from sanic_cors.extension import cors
 from tortoise.contrib.sanic import register_tortoise
 
 from TortoiseRouter import TortoiseRouter
@@ -74,8 +75,9 @@ class Application(Sanic):
         )
 
     def app_init(self):
-        # CORS
-        CORS(self)
+
+        realm = SanicPluginRealm(self)
+        realm.register_plugin(cors, automatic_options=True)
 
         # Master Slave Config of MySQL Connection Info
         config = {


### PR DESCRIPTION
# 변경점

1. HTTP 201 응답에 Location 이 포함된 데이터의 경우 Access-Control-Allow-Origin 을 * 값을 가지는 Key Value 추가.

# 변경 사유

Location 값을 접근하기 위하여

# 테스트 방법

Location 의 값을 체크하기 전 Access-Control-Allow-Origin의 값이 *로 들어가있는지 체크한다.